### PR TITLE
fixes sass --watch for mac osx maverick and other bits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# vim ~tmp files
+*.swp
+*.un~
+
+# ignore bourbon install so that it is the latest build
+# for developers that need it
+assets/scss/bourbon/*
+
+# ignore the sass-cache/
+.sass-cache/*
+**/.sass-cache/*

--- a/README.md
+++ b/README.md
@@ -4,32 +4,82 @@
 Uno for Ghost is the result of my first 'mini-project' of 2014. The theme features a minimal, responsive design with a cover page, disqus comment integration, foundation icons and various colour options.
 
 
-## Demo  
+## Demo
 There's a demo of the theme running on my personal website, [daleanthony.com](http://daleanthony.com)
 
 
 ## Features
 
-**Cover page**  
-The landing page for Uno is a full screen 'cover' featuring your avatar, blog title, mini-bio and cover image. 
+**Cover page**
+The landing page for Uno is a full screen 'cover' featuring your avatar, blog title, mini-bio and cover image.
 
-**Built with SASS, using BEM**  
+**Built with SASS, using BEM**
 If you know HTML and CSS making modifications to the theme should be super simple.
 
-**Responsive**  
+**Responsive**
 Uno looks great on all devices, even those weird phablets that nobody buys.
 
-**Disqus comments**  
+**Disqus comments**
 Disqus integration allows users to comment on your posts.
 
-**Foundation icons**  
+**Foundation icons**
 Uno contains the [Foundation icon font by Zurb](http://zurb.com/playground/foundation-icon-fonts-3) which means you can easily add icons. A full list of available icons can be found on the [Foundation Icon](http://zurb.com/playground/foundation-icon-fonts-3) website.
 
-**No-JS fallback**  
+**No-JS fallback**
 While JS is widely used, some themes and websites don't provide fallback for when no JS is available (I'm looking at you [Squarespace](http://blog.squarespace.com/)). If for some weird reason a visitor has JS disabled your blog will still be useable.
 
-**Development**  
-Ghost is still a work in progress with many features not yet implemented, as Ghost gets updated new features will be added to Uno.
-
-**1 theme, 5 colour options**  
+**1 theme, 5 colour options**
 Uno includes 5 different colour options for you to chose from.
+
+**Future**
+Ghost is still a work in progress with many features not yet implemented, as Ghost gets updated new features will be added to Uno. 
+
+## Development
+
+In order to develop or make changes to the theme you will need to have the sass compiler and bourbon both installed.  If you are running a Ghost environment locally then you should already have these installed as those are required to run Ghost.
+
+To check installation run the following commands from a terminal and you should see the `> cli output` but your version numbers may vary.
+
+** SASS **
+```bash
+
+sass -v
+> Sass 3.3.4 (Maptastic Maple)
+```
+
+** Bourbon **
+```bash
+
+bourbon help
+> Bourbon 3.1.8
+```
+
+Once installation is verified we will need to go mount the bourbon mixins into the `scss` folder.
+
+From the project root run `bourbon install` with the correct path
+```bash
+bourbon install --path assets/scss
+> bourbon files installed to assets/scss/bourbon/
+```
+
+Now that we have the bourbon mixins inside of the `scss` src folder we can now use the sass cli command to watch the scss files for changes and recompile them.
+
+```bash
+sass --watch assets/scss:assets/css
+>>>> Sass is watching for changes. Press Ctrl-C to stop.
+```
+
+** MacOSX Maverick **
+
+Some people may receive this error when trying to run the `sass --watch` command
+
+```bash
+> LoadError: cannot load such file -- rb-fsevent
+  Use --trace for backtrace.
+```
+
+This is a known issue with the [Sass on MaxOS Maverick](http://stackoverflow.com/questions/22413834/getting-error-when-using-command-line-for-sass-to-watch-files) as indicated install the `rb-fsevent` gem
+
+```bash
+gem install rb-fsevent
+```

--- a/assets/scss/global.scss
+++ b/assets/scss/global.scss
@@ -270,7 +270,7 @@ pre {
 .logo {
   border-radius: 50%;
   border: 3px solid #FFF;
-  @include box-shadow(0 0 1px 1px rgba(000,000,000,.3));
+  box-shadow:0 0 1px 1px rgba(000,000,000,.3);
 }
 
 // ------------------------------

--- a/assets/scss/sections/_post.scss
+++ b/assets/scss/sections/_post.scss
@@ -34,7 +34,7 @@
     height: 22px;
     margin: 0 .3em -.4em 0;
     border: none;
-    @include box-shadow(none);
+    box-shadow:none;
   }
 
 // ------------------------------

--- a/assets/scss/uno.scss
+++ b/assets/scss/uno.scss
@@ -1,4 +1,4 @@
-@import 'bourbon';
+@import 'bourbon/bourbon';
 @import 'http://fonts.googleapis.com/css?family=Raleway:400,700|Roboto+Slab:300,400)';
 
 // ------------------------------

--- a/default.hbs
+++ b/default.hbs
@@ -27,7 +27,7 @@
     <link href="/apple-touch-icon-precomposed.png" rel="apple-touch-icon">
 
     {{! Styles and Scripts }}
-    <link rel="stylesheet" type="text/css" href="{{asset "css/screen.css"}}" />
+    <link rel="stylesheet" type="text/css" href="{{asset "css/uno.css"}}" />
 
     {{! Ghost Magic }}
     {{ghost_head}}


### PR DESCRIPTION
Ran into several issues in customizing the theme using sass --watch  this patch contains the following adjustments.
- Updated instructions in Readme.md for setting up sass and fixing [mac osx maverick](http://stackoverflow.com/questions/22413834/getting-error-when-using-command-line-for-sass-to-watch-files)
  - Instructions include how to install bourbon in the correct path
- [Bourbon Deprecation box-shadow](https://github.com/thoughtbot/bourbon/issues/156) warnings issued during `sass --watch`
- `default.hbs` links to `screen.css` which doesn't reflect the correct changes from `sass --watch` instead use `uno.css`.  Curious if I'm missing something with `screen.css`?
- Add `.gitignore` so that we don't include `bourbon/bourbon` installation as this should always be handled by developer to ensure latest bourbon.
