### PR TITLE
Ghost 0.5 updated

### DIFF
--- a/partials/pagination.hbs
+++ b/partials/pagination.hbs
@@ -2,10 +2,10 @@
 
 <nav class="pagination" role="navigation">
     {{#if prev}}
-        <a class="newer-posts pagination__newer btn btn-small btn-tertiary" href="{{pageUrl prev}}#blog">&larr; Newer Posts</a>
+        <a class="newer-posts pagination__newer btn btn-small btn-tertiary" href="{{page_url prev}}#blog">&larr; Newer Posts</a>
     {{/if}}
     <span class="pagination__page-number">Page {{page}} of {{pages}}</span>
     {{#if next}}
-        <a class="older-posts pagination__older btn btn-small btn-tertiary" href="{{pageUrl next}}#blog">Older Posts &rarr;</a>
+        <a class="older-posts pagination__older btn btn-small btn-tertiary" href="{{page_url next}}#blog">Older Posts &rarr;</a>
     {{/if}}
 </nav>


### PR DESCRIPTION
```
Warning: Warning: pageUrl is deprecated, please use page_url instead
The helper pageUrl has been replaced with page_url in Ghost 0.4.2, and will be removed entirely in Ghost 0.6
```
