### PR TITLE
hide content-wrapper div when on homepage

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -4,6 +4,7 @@ $(document).ready(function() {
 
   $('a.blog-button').click(function() {
     if ($('.panel-cover').hasClass('panel-cover--collapsed')) return;
+    $('.content-wrapper').show();
     currentWidth = $('.panel-cover').width();
     if (currentWidth < 960) {
       $('.panel-cover').addClass('panel-cover--collapsed');
@@ -16,6 +17,10 @@ $(document).ready(function() {
 
   if (window.location.hash && window.location.hash == "#blog") {
     $('.panel-cover').addClass('panel-cover--collapsed');
+  }
+
+  if (window.location.pathname == "/" && !window.location.hash) {
+    $('.content-wrapper').hide();
   }
 
   if (window.location.pathname.substring(0, 5) == "/tag/") {


### PR DESCRIPTION
This fixes a scrolling issue I noticed. When you're on the homepage, the list of blog post summaries is present, but off screen. However, its height still influences the scrollable areas, so when you scroll, the scrollbar moves, but the page doesn't.

This fix hides the content-wrapper div if you're on the homepage, and then shows it when you click the blog button.
